### PR TITLE
add address in reply text to deposit command.

### DIFF
--- a/DiscordBot/Modules/CurrencyModuleBase.cs
+++ b/DiscordBot/Modules/CurrencyModuleBase.cs
@@ -66,7 +66,11 @@ namespace CCWallet.DiscordBot.Modules
         public virtual async Task CommandDepositAsync()
         {
             await Context.Channel.TriggerTypingAsync();
-            await ReplySuccessAsync(_("Your {0} deposit address.", Wallet.Currency.Name), CreateEmbed(new EmbedBuilder()
+            await ReplySuccessAsync(String.Join("\n", new[]
+            {
+                _("Your {0} address.", Wallet.Currency.Name),
+                Wallet.Address.ToString(),
+            }), CreateEmbed(new EmbedBuilder()
             {
                 Color = Color.DarkBlue,
                 Title = _("Deposit Address"),


### PR DESCRIPTION
I added user's address in reply message to deposit command.

# why?

In smartphone discord app, users can NOT copy the address in embed.

# comment

If a better way comes up to it, reject this and write your code.