### PR TITLE
Enable optional comment for tip command.

### DIFF
--- a/DiscordBot/Modules/CurrencyModuleBase.cs
+++ b/DiscordBot/Modules/CurrencyModuleBase.cs
@@ -104,7 +104,7 @@ namespace CCWallet.DiscordBot.Modules
         [Command(BotCommand.Tip)]
         [RequireContext(ContextType.Guild | ContextType.Group)]
         [RequireBotPermission(ChannelPermission.SendMessages | ChannelPermission.AddReactions | ChannelPermission.EmbedLinks)]
-        public virtual async Task CommandTipAsync(IUser user, decimal amount)
+        public virtual async Task CommandTipAsync(IUser user, decimal amount, params string[] comment)
         {
             await Context.Channel.TriggerTypingAsync();
             await Wallet.UpdateBalanceAsync();

--- a/DiscordBot/Modules/XPCoinModule.cs
+++ b/DiscordBot/Modules/XPCoinModule.cs
@@ -13,7 +13,7 @@ namespace CCWallet.DiscordBot.Modules
         public override async Task CommandHelpAsync(string command = null) => await base.CommandHelpAsync(command);
         public override async Task CommandBalanceAsync() => await base.CommandBalanceAsync();
         public override async Task CommandDepositAsync() => await base.CommandDepositAsync();
-        public override async Task CommandTipAsync(IUser user, decimal amount) => await base.CommandTipAsync(user, amount);
+        public override async Task CommandTipAsync(IUser user, decimal amount, params string[] comment) => await base.CommandTipAsync(user, amount, comment);
         public override async Task CommandWithdrawAsync(string address, decimal amount) => await base.CommandWithdrawAsync(address, amount);
     }
 }


### PR DESCRIPTION
Some users append comment in Xp-Bot's tip command.

example:
> ,tip @userB 100 thank u!

So enable option in CCWallet's tip command.
(This option doesn't affect result.)

example:
> !xp tip @userA 99 u r welcome!

uhm? 1xp is ... There are also such things.