### PR TITLE
Fix : CalculateFee Bug

### DIFF
--- a/DiscordBot/Currencies/XPCoin.cs
+++ b/DiscordBot/Currencies/XPCoin.cs
@@ -199,8 +199,8 @@ namespace CCWallet.DiscordBot.Currencies
             var bytes = tx.GetSerializedSize();
             var coins = unspents.Where(c => op.Contains(c.Outpoint));
 
-            var priority = coins.Sum(c => Convert.ToDouble(c.Amount / 100 * c.Confirms)) / bytes;                        // NOTICE: Change Unit (BTC to XP)
-            var fee = priority > 576000d && bytes < 1000 ? Money.Zero : XPCoinTransaction.MinTxFee * (1 + bytes / 1000); // NOTICE: Change Unit (BTC to XP)
+            var priority = coins.Sum(c => c.Amount.ToDecimal(MoneyUnit.Satoshi) / 100 * c.Confirms) / bytes;                        // NOTICE: Change Unit (BTC to XP)
+            var fee = priority > 576000m && bytes < 1000 ? Money.Zero : XPCoinTransaction.MinTxFee * (1 + bytes / 1000); // NOTICE: Change Unit (BTC to XP)
 
             fee += tx.Outputs.Count(o => o.Value < Money.CENT) * XPCoinTransaction.MinTxFee;
 


### PR DESCRIPTION
# What?

Fixing the problem that occurs when sending huge amount and long unspent UTXO.

# Why occurs?

Money's member variable `Amount` is long.
[this line](https://github.com/foo87b/CCWallet/blob/master/DiscordBot/Currencies/XPCoin.cs#L202) is below:
```csharp
((double)(long / int * int) + (double)(long / int * int) + ... + (double)(long / int * int)) / int
```
If the Amount or Confirmation count is huge, overflow the Int64(long) maximum value.
Appending, rounding is occurs in sum as double value.
(after this fix, no rounding occurs because using decimal.)

# Others

I thought that using `ToDecimal(MoneyUnit.Bit)`.
But this line meaning "1satoshi -> 0.000001XP". Not "satoshi -> Bit".
Then, I don't use Convert to Bit.

(English is difficult for me! Sorry!)